### PR TITLE
switch to sdkman_enable_gvm_alias on usage page

### DIFF
--- a/usage.html
+++ b/usage.html
@@ -254,8 +254,8 @@ sdkman_auto_selfupdate=true|false
 # HERE BE DRAGONS....
 sdkman_insecure_ssl=true|false
 
-# disable GVM alias, for users of the Go Version Manager
-sdkman_disable_gvm_alias=true|false
+# enable GVM alias, for users of the Go Version Manager
+sdkman_enable_gvm_alias=true|false
 
 # configure curl timeouts
 sdkman_curl_connect_timeout=5


### PR DESCRIPTION
In case the PR https://github.com/sdkman/sdkman-cli/pull/608 gets accepted, we could have this merged to reflect correct information. thanks!