### PR TITLE
get rid of gvm config all together

### DIFF
--- a/usage.html
+++ b/usage.html
@@ -254,9 +254,6 @@ sdkman_auto_selfupdate=true|false
 # HERE BE DRAGONS....
 sdkman_insecure_ssl=true|false
 
-# disable GVM alias, for users of the Go Version Manager
-sdkman_disable_gvm_alias=true|false
-
 # configure curl timeouts
 sdkman_curl_connect_timeout=5
 sdkman_curl_max_time=4


### PR DESCRIPTION
this PR get rids of information related to gvm alias from the usage page.