### PR TITLE
Fix typo in Activator SDK description

### DIFF
--- a/sdks.html
+++ b/sdks.html
@@ -50,7 +50,7 @@
                         </div><div id='content' class='page-1'><div class='row'><div class='row-fluid'><div class='col-lg-3'><a class="twitter-timeline" data-dnt="true" href="https://twitter.com/search?q=sdkman" data-widget-id="609819838945566720">Tweets about sdkman</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script></div><div class='col-lg-8 col-lg-pull-0'><h1><a name='main'></a><i class='fa fa-cloud-download'></i> SDK Installation Candidates</h1><h4>Activator</h4>
 <a href='http://www.lightbend.com/activator/download' target='_blank'>http://www.lightbend.com/activator/download</a></br>
-<p>Typesafe is a GUI/CLI tool to help with building reactive applicaions. It uses
+<p>Typesafe is a GUI/CLI tool to help with building reactive applications. It uses
 sbt (simple build tool) behind the scenes to build, run, and test your project.
 It provides a code editing interface, and provides templaes and seeds for you to
 clone and use.</p>


### PR DESCRIPTION
This PR fixes a typo in the "Activator" SDK description text.