### PR TITLE
Fixed OpenCollective data retrieval.

### DIFF
--- a/src/lib/services/open-collective.ts
+++ b/src/lib/services/open-collective.ts
@@ -46,6 +46,8 @@ async function getOpenCollective(key: OpenCollectiveKeys) {
   } catch (err) {
     console.error(err);
   }
+
+  return [];
 }
 
 export const openCollectiveService = {


### PR DESCRIPTION
getOpenCollective method returns an empty array if the network call has an error

Related to: #109 