### PR TITLE
Provide actual command for zsh

### DIFF
--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -14,6 +14,10 @@ Just launch a new terminal and type in:
 ```shell
 curl -s "https://get.sdkman.io" | bash
 ```
+or on zsh – e.g. on macOS:
+```shell
+curl -s "https://get.sdkman.io" | zsh
+```
 
 Follow the on-screen instructions to wrap up the installation. Afterward, open a
 new terminal or run the following in the same shell:


### PR DESCRIPTION
I propose to show the actual command to be used with zsh, especially as the bash command would not work on macOS due to the old bash version installed by default.

The bash command might be confusing for people when it fails due to the version of bash, especially new macOS users.